### PR TITLE
Replace MyGet references with AzureDevOps

### DIFF
--- a/Submit-Pull-Request.md
+++ b/Submit-Pull-Request.md
@@ -14,4 +14,4 @@ Please make certain that the PR successfully passes all three status check requi
 
 If the PR passes all the requirements above and reviewers have signed off, the PR will be merged. 
 
-Once merged, you can get a pre-release package of the toolkit by adding this ([Nuget repo](https://dotnet.myget.org/F/uwpcommunitytoolkit/api/v3/index.json) | [Gallery](https://dotnet.myget.org/gallery/uwpcommunitytoolkit)) to your Visual Studio.
+Once merged, you can get a pre-release package of the toolkit by adding this ([Azure DevOps feed](https://pkgs.dev.azure.com/dotnet/WindowsCommunityToolkit/_packaging/WindowsCommunityToolkit-MainLatest/nuget/v3/index.json) | [Gallery](https://dev.azure.com/dotnet/WindowsCommunityToolkit/_packaging?_a=feed&feed=WindowsCommunityToolkit-MainLatest)) to your Visual Studio.

--- a/Windows-Community-Toolkit.md
+++ b/Windows-Community-Toolkit.md
@@ -8,6 +8,6 @@ The Windows Community Toolkit is a collection of helper functions, custom contro
 | Target | Branch | Status | Recommended package version |
 | ------ | ------ | ------ | ------ |
 | Production | rel/6.1.0 | [![Build Status](https://dev.azure.com/dotnet/WindowsCommunityToolkit/_apis/build/status/Toolkit-CI?branchName=rel/6.1.0)](https://dev.azure.com/dotnet/WindowsCommunityToolkit/_build/latest?definitionId=10&branchName=rel/6.1.0) | [![NuGet](https://img.shields.io/nuget/v/Microsoft.Toolkit.Uwp.svg)](https://www.nuget.org/profiles/Microsoft.Toolkit) | 
-| Pre-release beta testing | master | [![Build Status](https://dev.azure.com/dotnet/WindowsCommunityToolkit/_apis/build/status/Toolkit-CI?branchName=master)](https://dev.azure.com/dotnet/WindowsCommunityToolkit/_build/latest?definitionId=10) | [![MyGet](https://img.shields.io/dotnet.myget/uwpcommunitytoolkit/vpre/Microsoft.Toolkit.Uwp.svg)](https://dotnet.myget.org/gallery/uwpcommunitytoolkit) |
+| Pre-release beta testing | master | [![Build Status](https://dev.azure.com/dotnet/WindowsCommunityToolkit/_apis/build/status/Toolkit-CI?branchName=master)](https://dev.azure.com/dotnet/WindowsCommunityToolkit/_build/latest?definitionId=10) | [![DevOps](https://vsrm.dev.azure.com/dotnet/_apis/public/Release/badge/696bc9fd-f160-4e97-a1bd-7cbbb3b58f66/1/1)](https://dev.azure.com/dotnet/WindowsCommunityToolkit/_packaging?_a=feed&feed=WindowsCommunityToolkit-MainLatest) |
 
 


### PR DESCRIPTION
<!-- When opening a PR, start by forking this repository. Then, you'll need to create a new branch derived from the forked `main` branch. 

Once you have established all the changes in the forked branch then sync your PR with the main branch of [WindowsCommunityToolkit-wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit-wiki/pulls) repository -->


## What changes does this PR introduce?
<!-- Please describe the updated information in detail -->

Remove outdated references to MyGet as feeds are no longer available there.
Replace with the new/equivalent Azure DevOps feeds.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Correctly picked the forked new branch to base the change off (`main`)
- [x] Ran against a spell and grammar checker 


## Other information
